### PR TITLE
Separating OVN NB and SB database processes

### DIFF
--- a/debian/ovn-central.template
+++ b/debian/ovn-central.template
@@ -2,4 +2,13 @@
 
 # OVN_CTL_OPTS: Extra options to pass to ovs-ctl.  This is, for example,
 # a suitable place to specify --ovn-northd-wrapper=valgrind.
-# OVN_CTL_OPTS=
+OVN_CTL_OPTS=--db-nb-port="6641" \
+    --db-nb-sock="/var/run/openvswitch/nb_db.sock" \
+    --db-nb-pid="/var/run/openvswitch/ovsdb-server-nb.pid" \
+    --db-nb-file="/etc/openvswitch/ovnnb.db" \
+    --ovn-nb-log="-vconsole:off --log-file=/var/log/openvswitch/ovsdb-server-nb.log" \
+    --db-sb-port="6640" \
+    --db-sb-sock="/var/run/openvswitch/sb_db.sock" \
+    --db-sb-pid="/var/run/openvswitch/ovsdb-server-sb.pid" \
+    --db-sb-file="/etc/openvswitch/ovnsb.db" \
+    --ovn-sb-log="-vconsole:off --log-file=/var/log/openvswitch/ovsdb-server-sb.log"

--- a/ovn/northd/ovn-northd.c
+++ b/ovn/northd/ovn-northd.c
@@ -52,7 +52,8 @@ struct northd_context {
 static const char *ovnnb_db;
 static const char *ovnsb_db;
 
-static const char *default_db(void);
+static const char *default_nb_db(void);
+static const char *default_sb_db(void);
 
 /* Pipeline stages. */
 
@@ -168,7 +169,7 @@ Options:\n\
   -h, --help                display this help message\n\
   -o, --options             list available options\n\
   -V, --version             display version information\n\
-", program_name, program_name, default_db(), default_db());
+", program_name, program_name, default_nb_db(), default_sb_db());
     daemon_usage();
     vlog_usage();
     stream_usage("database", true, true, false);
@@ -1922,15 +1923,26 @@ ovnsb_db_run(struct northd_context *ctx)
 }
 
 
-static char *default_db_;
+static char *default_nb_db_;
 
 static const char *
-default_db(void)
+default_nb_db(void)
 {
-    if (!default_db_) {
-        default_db_ = xasprintf("unix:%s/db.sock", ovs_rundir());
+    if (!default_nb_db_) {
+        default_nb_db_ = xasprintf("unix:%s/ovnnb_db.sock", ovs_rundir());
     }
-    return default_db_;
+    return default_nb_db_;
+}
+
+static char *default_sb_db_;
+
+static const char *
+default_sb_db(void)
+{
+    if (!default_sb_db_) {
+        default_sb_db_ = xasprintf("unix:%s/ovnsb_db.sock", ovs_rundir());
+    }
+    return default_sb_db_;
 }
 
 static void
@@ -1992,11 +2004,11 @@ parse_options(int argc OVS_UNUSED, char *argv[] OVS_UNUSED)
     }
 
     if (!ovnsb_db) {
-        ovnsb_db = default_db();
+        ovnsb_db = default_sb_db();
     }
 
     if (!ovnnb_db) {
-        ovnnb_db = default_db();
+        ovnnb_db = default_nb_db();
     }
 
     free(short_options);
@@ -2112,7 +2124,8 @@ main(int argc, char *argv[])
     ovsdb_idl_loop_destroy(&ovnsb_idl_loop);
     service_stop();
 
-    free(default_db_);
+    free(default_nb_db_);
+    free(default_sb_db_);
     exit(res);
 }
 

--- a/ovn/utilities/ovn-ctl
+++ b/ovn/utilities/ovn-ctl
@@ -30,32 +30,81 @@ done
 ## start ##
 ## ----- ##
 
-upgrade_ovn_dbs () {
-    ovn_dbs=$(ovs-appctl -t ovsdb-server ovsdb-server/list-dbs 2>/dev/null)
-    for db in $ovn_dbs; do
-        case $db in
-            OVN*)
-                action "Removing $db from ovsdb-server" \
-                    ovs-appctl -t ovsdb-server ovsdb-server/remove-db $db
-                ;;
-        esac
-    done
-    upgrade_db "$DB_NB_FILE" "$DB_NB_SCHEMA"
-    upgrade_db "$DB_SB_FILE" "$DB_SB_SCHEMA"
-    for db in $DB_NB_FILE $DB_SB_FILE; do
-        action "Adding $db to ovsdb-server" \
-            ovs-appctl -t ovsdb-server ovsdb-server/add-db $db || exit 1
-    done
+pidfile_is_running () {
+    pidfile=$1
+    test -e "$pidfile" && pid=`cat "$pidfile"` && pid_exists "$pid"
+} >/dev/null 2>&1
+
+stop_ovsdb () {
+    if pidfile_is_running $DB_NB_PID; then
+        kill -9 $(cat $DB_NB_PID) 1>/dev/null 2>/dev/null
+        rm -f $DB_NB_PID 1>/dev/null 2>/dev/null
+    fi
+
+    if pidfile_is_running $DB_SB_PID; then
+        kill -9 $(cat $DB_SB_PID) 1>/dev/null 2>/dev/null
+        rm -f $DB_SB_PID 1>/dev/null 2>/dev/null
+    fi
+}
+
+start_ovsdb () {
+    # Check and eventually start ovsdb-server for Northbound DB
+    if ! pidfile_is_running $DB_NB_PID; then
+        upgrade_db "$DB_NB_FILE" "$DB_NB_SCHEMA" 1>/dev/null 2>/dev/null
+
+        set ovsdb-server
+
+        set "$@" --detach $OVN_NB_LOG --remote=punix:$DB_NB_SOCK --remote=ptcp:$DB_NB_PORT --pidfile=$DB_NB_PID
+
+        $@ $DB_NB_FILE
+    fi
+
+    # Check and eventually start ovsdb-server for Southbound DB
+    if ! pidfile_is_running $DB_SB_PID; then
+        upgrade_db "$DB_SB_FILE" "$DB_SB_SCHEMA" 1>/dev/null 2>/dev/null
+
+        set ovsdb-server
+
+        set "$@" --detach $OVN_SB_LOG --remote=punix:$DB_SB_SOCK --remote=ptcp:$DB_SB_PORT --pidfile=$DB_SB_PID
+        $@ $DB_SB_FILE
+    fi
+}
+
+status_ovsdb () {
+  if ! pidfile_is_running $DB_NB_PID; then
+      log_success_msg "OVN Northbound DB is not running"
+  else
+      log_success_msg "OVN Northbound DB is running"
+  fi
+
+  if ! pidfile_is_running $DB_SB_PID; then
+      log_success_msg "OVN Southbound DB is not running"
+  else
+      log_success_msg "OVN Southbound DB is running"
+  fi
 }
 
 start_northd () {
-    # We expect ovn-northd to be co-located with ovsdb-server handling both the
-    # OVN_Northbound and OVN_Southbound dbs.
-    upgrade_ovn_dbs
+  if test X"$OVN_MANAGE_OVSDB" = Xyes; then
+      start_ovsdb
+  fi
 
-    set ovn-northd
-    set "$@" -vconsole:emer -vsyslog:err -vfile:info
-    OVS_RUNDIR=${OVN_RUNDIR} start_daemon "$OVN_NORTHD_PRIORITY" "$OVN_NORTHD_WRAPPER" "$@"
+  if ! pidfile_is_running $DB_NB_PID; then
+      log_failure_msg "OVN Northbound DB is not running"
+      exit
+  fi
+  if ! pidfile_is_running $DB_SB_PID; then
+      log_failure_msg "OVN Southbound DB is not running"
+      exit
+  fi
+
+  if daemon_is_running ovn-northd; then
+      log_success_msg "OVN Northbound is already running"
+  else
+      set ovn-northd
+      set "$@" $OVN_NORTHD_LOG --ovnnb-db=unix:$DB_NB_SOCK --ovnsb-db=unix:$DB_SB_SOCK
+      OVS_RUNDIR=${OVN_RUNDIR} start_daemon "$OVN_NORTHD_PRIORITY" "$OVN_NORTHD_WRAPPER" "$@"
+  fi
 }
 
 start_controller () {
@@ -70,6 +119,10 @@ start_controller () {
 
 stop_northd () {
     OVS_RUNDIR=${OVN_RUNDIR} stop_daemon ovn-northd
+
+    if test X"$OVN_MANAGE_OVSDB" = Xyes; then
+        stop_ovsdb
+    fi
 }
 
 stop_controller () {
@@ -90,24 +143,47 @@ restart_controller () {
     start_controller
 }
 
+restart_ovsdb () {
+    stop_ovsdb
+    start_ovsdb
+}
+
 ## ---- ##
 ## main ##
 ## ---- ##
 
 set_defaults () {
-    DB_SOCK=$rundir/db.sock
-    DB_NB_FILE=$dbdir/ovnnb.db
-    DB_SB_FILE=$dbdir/ovnsb.db
-    DB_NB_SCHEMA=$datadir/ovn-nb.ovsschema
-    DB_SB_SCHEMA=$datadir/ovn-sb.ovsschema
+  OVN_DIR=$rundir
+  OVN_MANAGE_OVSDB=yes
 
-    OVN_NORTHD_PRIORITY=-10
-    OVN_NORTHD_WRAPPER=
-    OVN_CONTROLLER_PRIORITY=-10
-    OVN_CONTROLLER_WRAPPER=
+  DB_NB_SOCK=$OVN_DIR/ovnnb_db.sock
+  DB_NB_PID=$OVN_DIR/ovnnb_db.pid
+  DB_NB_FILE=$OVN_DIR/ovnnb_db.db
+  DB_NB_PORT=6641
 
-    OVS_RUNDIR=${OVS_RUNDIR:-${rundir}}
-    OVN_RUNDIR=${OVN_RUNDIR:-${OVS_RUNDIR}}
+  DB_SB_SOCK=$OVN_DIR/ovnsb_db.sock
+  DB_SB_PID=$OVN_DIR/ovnsb_db.pid
+  DB_SB_FILE=$OVN_DIR/ovnsb_db.db
+  DB_SB_PORT=6642
+
+  DB_NB_SCHEMA=$datadir/ovn-nb.ovsschema
+  DB_SB_SCHEMA=$datadir/ovn-sb.ovsschema
+
+  DB_SOCK=$rundir/db.sock
+  DB_CONF_FILE=$dbdir/conf.db
+
+  OVN_NORTHD_PRIORITY=-10
+  OVN_NORTHD_WRAPPER=
+  OVN_CONTROLLER_PRIORITY=-10
+  OVN_CONTROLLER_WRAPPER=
+
+  OVS_RUNDIR=${OVS_RUNDIR:-${rundir}}
+  OVN_RUNDIR=${OVN_RUNDIR:-${OVS_RUNDIR}}
+
+  OVN_CONTROLLER_LOG="-vconsole:emer -vsyslog:err -vfile:info"
+  OVN_NORTHD_LOG="-vconsole:emer -vsyslog:err -vfile:info"
+  OVN_NB_LOG="-vconsole:off"
+  OVN_SB_LOG="-vconsole:off"
 }
 
 set_option () {
@@ -134,10 +210,13 @@ startup scripts.  System administrators should not normally invoke it directly.
 
 Commands:
   start_northd           start ovn-northd
+  start_ovsdb            start ovn related ovsdb-server processes
   start_controller       start ovn-controller
   stop_northd            stop ovn-northd
+  stop_ovsdb             stop ovn related ovsdb-server processes
   stop_controller        stop ovn-controller
   restart_northd         restart ovn-northd
+  restart_ovsdb          restart ovn related ovsdb-server processes
   restart_controller     restart ovn-controller
 
 Options:
@@ -145,6 +224,11 @@ Options:
   --ovn-northd-wrapper=WRAPPER   run with a wrapper like valgrind for debugging
   --ovn-controller-priority=NICE     set ovn-northd's niceness (default: $OVN_CONTROLLER_PRIORITY)
   --ovn-controller-wrapper=WRAPPER   run with a wrapper like valgrind for debugging
+  --ovn-manage-ovsdb=no              manage ovsdb separately from start_northd and stop_northd
+  --ovn-controller-log=STRING        ovn controller process logging params (default: $OVN_CONTROLLER_LOG)
+  --ovn-northd-log=STRING            ovn northd process logging params (default: $OVN_NORTHD_LOG)
+  --ovn-nb-log=STRING             ovn NB ovsdb-server processes logging params (default: $OVN_NB_LOG)
+  --ovn-sb-log=STRING             ovn SB ovsdb-server processes logging params (default: $OVN_SB_LOG)
   -h, --help                     display this help message
 
 File location options:
@@ -153,6 +237,9 @@ File location options:
   --db-sb-file=FILE    OVN_Southbound db file (default: $DB_SB_FILE)
   --db-nb-schema=FILE  OVN_Northbound db file (default: $DB_NB_SCHEMA)
   --db-sb-schema=FILE  OVN_Southbound db file (default: $DB_SB_SCHEMA)
+  --db-nb-port=PORT    OVN Northbound db ptcp port (default: $DB_NB_PORT)
+  --db-sb-port=PORT    OVN Southbound db ptcp port (default: $DB_SB_PORT)
+  --ovn-dir=FILE       OVN Databases directory (default: $OVN_DIR)
 
 Default directories with "configure" option and environment variable override:
   logs: /usr/local/var/log/openvswitch (--with-logdir, OVS_LOGDIR)
@@ -210,11 +297,17 @@ case $command in
     start_northd)
         start_northd
         ;;
+    start_ovsdb)
+        start_ovsdb
+        ;;
     start_controller)
         start_controller
         ;;
     stop_northd)
         stop_northd
+        ;;
+    stop_ovsdb)
+       stop_ovsdb
         ;;
     stop_controller)
         stop_controller
@@ -222,11 +315,17 @@ case $command in
     restart_northd)
         restart_northd
         ;;
+    restart_ovsdb)
+        restart_ovsdb
+        ;;
     restart_controller)
         restart_controller
         ;;
     status_northd)
         daemon_status ovn-northd || exit 1
+        ;;
+    status_ovsdb)
+        status_ovsdb
         ;;
     status_controller)
         daemon_status ovn-controller || exit 1

--- a/ovn/utilities/ovn-nbctl.c
+++ b/ovn/utilities/ovn-nbctl.c
@@ -142,7 +142,7 @@ nbctl_default_db(void)
     if (!def) {
         def = getenv("OVN_NB_DB");
         if (!def) {
-            def = ctl_default_db();
+            def = xasprintf("unix:%s/ovnnb_db.sock", ovs_rundir());
         }
     }
     return def;

--- a/ovn/utilities/ovn-sbctl.c
+++ b/ovn/utilities/ovn-sbctl.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "db-ctl-base.h"
+#include "dirs.h"
 
 #include "command-line.h"
 #include "compiler.h"
@@ -154,7 +155,7 @@ sbctl_default_db(void)
     if (!def) {
         def = getenv("OVN_SB_DB");
         if (!def) {
-            def = ctl_default_db();
+            def = xasprintf("unix:%s/ovnsb_db.sock", ovs_rundir());
         }
     }
     return def;

--- a/tests/ovn-controller-vtep.at
+++ b/tests/ovn-controller-vtep.at
@@ -57,7 +57,7 @@ m4_define([OVN_CONTROLLER_VTEP_START],
    OVS_WAIT_UNTIL([test -n "`vtep-ctl show | grep Physical_Port`"])
 
    dnl Start ovn-northd.
-   AT_CHECK([ovn-nbctl lswitch-add br-test])
+   AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lswitch-add br-test])
    AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/db.sock], [0], [], [stderr])
    on_exit "kill `cat ovn-northd.pid`"
    AT_CHECK([[sed < stderr '
@@ -102,9 +102,10 @@ m4_define([OVN_CONTROLLER_VTEP_STOP],
 # $3: physical vtep gateway name
 # $4: logical switch name on vtep gateway chassis
 m4_define([OVN_NB_ADD_VTEP_PORT], [
-AT_CHECK([ovn-nbctl lport-add $1 $2])
-AT_CHECK([ovn-nbctl lport-set-type $2 vtep])
-AT_CHECK([ovn-nbctl lport-set-options $2 vtep-physical-switch=$3 vtep-logical-switch=$4])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add $1 $2])
+
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-type $2 vtep])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-options $2 vtep-physical-switch=$3 vtep-logical-switch=$4])
 ])
 
 ##############################################
@@ -114,8 +115,8 @@ AT_SETUP([ovn-controller-vtep - test chassis])
 OVN_CONTROLLER_VTEP_START
 
 # verifies the initial ovn-sb db configuration.
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl show | grep Chassis`"])
-AT_CHECK([ovn-sbctl show], [0], [dnl
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock show | grep Chassis`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock show], [0], [dnl
 Chassis br-vtep
     Encap vxlan
         ip: "1.2.3.4"
@@ -123,7 +124,7 @@ Chassis br-vtep
 
 # deletes the chassis via ovn-sbctl and check that it is readded back
 # with the log.
-AT_CHECK([ovn-sbctl chassis-del br-vtep])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock chassis-del br-vtep])
 OVS_WAIT_UNTIL([test -n "`grep WARN ovn-controller-vtep.log`"])
 AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log], [0], [dnl
 |WARN|Chassis for VTEP physical switch (br-vtep) disappears, maybe deleted by ovn-sbctl, adding it back
@@ -132,43 +133,43 @@ AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log], [0], [dnl
 # changes the tunnel_ip on physical switch, watches the update of chassis's
 # encap.
 AT_CHECK([vtep-ctl set Physical_Switch br-vtep tunnel_ips=1.2.3.5])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl show | grep 1\.2\.3\.5`"])
-AT_CHECK([ovn-sbctl --columns=ip list Encap | cut -d ':' -f2 | tr -d ' '], [0], [dnl
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock show | grep 1\.2\.3\.5`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=ip list Encap | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 "1.2.3.5"
 ])
 
 # adds vlan_bindings to physical ports.
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0 -- bind-ls br-vtep p0 200 lswitch0 -- bind-ls br-vtep p1 300 lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Chassis | grep -- lswitch0`"])
-AT_CHECK([ovn-sbctl --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Chassis | grep -- lswitch0`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
 [["lswitch0"]]
 ])
 
 # adds another logical switch and new vlan_bindings.
 AT_CHECK([vtep-ctl add-ls lswitch1 -- bind-ls br-vtep p0 300 lswitch1])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Chassis | grep -- lswitch1`"])
-AT_CHECK([ovn-sbctl --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' '], [0], [dnl
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Chassis | grep -- lswitch1`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 [["lswitch0","lswitch1"]]
 ])
 
 # unbinds one port from lswitch0, nothing should change.
 AT_CHECK([vtep-ctl unbind-ls br-vtep p0 200])
 OVS_WAIT_UNTIL([test -z "`vtep-ctl --columns=vlan_bindings list physical_port p0 | grep -- '200='`"])
-AT_CHECK([ovn-sbctl --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
 [["lswitch0","lswitch1"]]
 ])
 
 # unbinds all ports from lswitch0.
 AT_CHECK([vtep-ctl unbind-ls br-vtep p0 100 -- unbind-ls br-vtep p1 300])
-OVS_WAIT_UNTIL([test -z "`ovn-sbctl list Chassis | grep -- br-vtep_lswitch0`"])
-AT_CHECK([ovn-sbctl --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
+OVS_WAIT_UNTIL([test -z "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Chassis | grep -- br-vtep_lswitch0`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' ' ], [0], [dnl
 [["lswitch1"]]
 ])
 
 # unbinds all ports from lswitch1.
 AT_CHECK([vtep-ctl unbind-ls br-vtep p0 300])
-OVS_WAIT_UNTIL([test -z "`ovn-sbctl list Chassis | grep -- br-vtep_lswitch1`"])
-AT_CHECK([ovn-sbctl --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' '], [0], [dnl
+OVS_WAIT_UNTIL([test -z "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Chassis | grep -- br-vtep_lswitch1`"])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=vtep_logical_switches list Chassis | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 [[]]
 ])
 
@@ -184,10 +185,10 @@ OVN_CONTROLLER_VTEP_START
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0 -- bind-ls br-vtep p1 300 lswitch0])
 # adds lport in ovn-nb database, and sets the type and options.
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-vtep_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-vtep_lswitch0`"])
 # should see one binding, associated to chassis of 'br-vtep'.
-chassis_uuid=$(ovn-sbctl --columns=_uuid list Chassis br-vtep | cut -d ':' -f2 | tr -d ' ')
-AT_CHECK_UNQUOTED([ovn-sbctl --columns=chassis list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' '], [0], [dnl
+chassis_uuid=$(ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=_uuid list Chassis br-vtep | cut -d ':' -f2 | tr -d ' ')
+AT_CHECK_UNQUOTED([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=chassis list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 ${chassis_uuid}
 ])
 
@@ -195,10 +196,10 @@ ${chassis_uuid}
 AT_CHECK([vtep-ctl add-ls lswitch1 -- bind-ls br-vtep p0 200 lswitch1])
 # adds lport in ovn-nb database for lswitch1.
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch1], [br-vtep], [lswitch1])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding | grep -- br-vtep_lswitch1`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding | grep -- br-vtep_lswitch1`"])
 # This is allowed, but not recommended, to have two vlan_bindings (to different vtep logical switches)
 # from one vtep gateway physical port in one ovn-nb logical swithch.
-AT_CHECK_UNQUOTED([ovn-sbctl --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort -d], [0], [dnl
+AT_CHECK_UNQUOTED([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort -d], [0], [dnl
 
 ${chassis_uuid}
 ${chassis_uuid}
@@ -206,11 +207,11 @@ ${chassis_uuid}
 
 # adds another lport in ovn-nb database for lswitch0.
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0_dup], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding | grep -- br-vtep_lswitch0_dup`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding | grep -- br-vtep_lswitch0_dup`"])
 # it is not allowed to have more than one ovn-nb logical port for the same
 # vtep logical switch on a vtep gateway chassis, so should still see only
 # two port_binding entries bound.
-AT_CHECK_UNQUOTED([ovn-sbctl --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort -d], [0], [dnl
+AT_CHECK_UNQUOTED([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort -d], [0], [dnl
 
 
 [[]]
@@ -225,9 +226,9 @@ AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log | sed 's/([[-
 # deletes physical ports from vtep.
 AT_CHECK([ovs-vsctl del-port p0 -- del-port p1])
 AT_CHECK([vtep-ctl del-port br-vtep p0 -- del-port br-vtep p1])
-OVS_WAIT_UNTIL([test -z "`ovn-sbctl list Chassis | grep -- br-vtep_lswitch`"])
+OVS_WAIT_UNTIL([test -z "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Chassis | grep -- br-vtep_lswitch`"])
 # should see empty chassis column in both binding entries.
-AT_CHECK_UNQUOTED([ovn-sbctl --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort], [0], [dnl
+AT_CHECK_UNQUOTED([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=chassis list Port_Binding | cut -d ':' -f2 | tr -d ' ' | sort], [0], [dnl
 
 
 [[]]
@@ -248,16 +249,16 @@ OVN_CONTROLLER_VTEP_START
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0])
 # adds lport in ovn-nb database, and sets the type and options.
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-vtep_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-vtep_lswitch0`"])
 
 # adds another lswitch 'br-void' in ovn-nb database.
-AT_CHECK([ovn-nbctl lswitch-add br-void])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lswitch-add br-void])
 # adds another vtep pswitch 'br-vtep-void' in vtep database.
 AT_CHECK([vtep-ctl add-ps br-vtep-void -- add-port br-vtep-void p0-void -- bind-ls br-vtep-void p0-void 100 lswitch0])
 # adds a conflicting logical port (both br-vtep_lswitch0 and br-vtep-void_lswitch0
 # are bound to the same logical switch, but they are on different datapath).
 OVN_NB_ADD_VTEP_PORT([br-void], [br-vtep-void_lswitch0], [br-vtep-void], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-vtep-void_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-vtep-void_lswitch0`"])
 OVS_WAIT_UNTIL([test -n "`grep WARN ovn-controller-vtep.log`"])
 # confirms the warning log.
 AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log | sed 's/([[-_0-9a-z]][[-_0-9a-z]]*)/()/g;s/(with tunnel key [[0-9]][[0-9]]*)/()/g' | uniq], [0], [dnl
@@ -266,12 +267,12 @@ AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log | sed 's/([[-
 
 # then deletes 'br-void' and 'br-vtep-void', should see 'br-vtep_lswitch0'
 # bound correctly.
-AT_CHECK([ovn-nbctl lswitch-del br-void])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lswitch-del br-void])
 # adds another vtep pswitch 'br-vtep-void' in vtep database.
 AT_CHECK([vtep-ctl del-ps br-vtep-void])
-OVS_WAIT_UNTIL([test -z "`ovn-sbctl list Port_Binding | grep br-vtep-void_lswitch0`"])
-chassis_uuid=$(ovn-sbctl --columns=_uuid list Chassis br-vtep | cut -d ':' -f2 | tr -d ' ')
-AT_CHECK_UNQUOTED([ovn-sbctl --columns=chassis list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' '], [0], [dnl
+OVS_WAIT_UNTIL([test -z "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding | grep br-vtep-void_lswitch0`"])
+chassis_uuid=$(ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=_uuid list Chassis br-vtep | cut -d ':' -f2 | tr -d ' ')
+AT_CHECK_UNQUOTED([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=chassis list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 ${chassis_uuid}
 ])
 
@@ -287,11 +288,11 @@ OVN_CONTROLLER_VTEP_START
 # port to 'br-test'.
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0])
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep -- br-vtep_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep -- br-vtep_lswitch0`"])
 
 # retrieves the expected tunnel key.
-datapath_uuid=$(ovn-sbctl --columns=datapath list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' ')
-tunnel_key=$(ovn-sbctl --columns=tunnel_key list Datapath_Binding ${datapath_uuid} | cut -d ':' -f2 | tr -d ' ')
+datapath_uuid=$(ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=datapath list Port_Binding br-vtep_lswitch0 | cut -d ':' -f2 | tr -d ' ')
+tunnel_key=$(ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=tunnel_key list Datapath_Binding ${datapath_uuid} | cut -d ':' -f2 | tr -d ' ')
 OVS_WAIT_UNTIL([test -z "`vtep-ctl --columns=tunnel_key list Logical_Switch | grep 0`"])
 # checks the vtep logical switch tunnel key configuration.
 AT_CHECK_UNQUOTED([vtep-ctl --columns=tunnel_key list Logical_Switch | cut -d ':' -f2 | tr -d ' '], [0], [dnl
@@ -301,9 +302,9 @@ ${tunnel_key}
 # creates a second physical switch in vtep database, and binds its p0 vlan-100
 # to the same logical switch 'lswitch0'.
 AT_CHECK([vtep-ctl add-ps br-vtep-void -- add-port br-vtep-void p0 -- bind-ls br-vtep-void p0 100 lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl --columns=name list Chassis  | grep -- br-vtep-void`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=name list Chassis  | grep -- br-vtep-void`"])
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep-void_lswitch0], [br-vtep-void], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep -- br-vtep-void_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep -- br-vtep-void_lswitch0`"])
 
 # checks the vtep logical switch tunnel key configuration.
 AT_CHECK_UNQUOTED([vtep-ctl --columns=tunnel_key list Logical_Switch | cut -d ':' -f2 | tr -d ' '], [0], [dnl
@@ -312,7 +313,7 @@ ${tunnel_key}
 
 # now, deletes br-vtep-void.
 AT_CHECK([vtep-ctl del-ps br-vtep-void])
-OVS_WAIT_UNTIL([test -z "`ovn-sbctl --columns=name list Chassis  | grep -- br-vtep-void`"])
+OVS_WAIT_UNTIL([test -z "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock --columns=name list Chassis  | grep -- br-vtep-void`"])
 # checks the vtep logical switch tunnel key configuration.
 AT_CHECK_UNQUOTED([vtep-ctl --columns=tunnel_key list Logical_Switch | cut -d ':' -f2 | tr -d ' '], [0], [dnl
 ${tunnel_key}
@@ -320,7 +321,7 @@ ${tunnel_key}
 
 # changes the ovn-nb logical port type so that it is no longer
 # vtep port.
-AT_CHECK([ovn-nbctl lport-set-type br-vtep_lswitch0 void])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-type br-vtep_lswitch0 void])
 OVS_WAIT_UNTIL([test -z "`vtep-ctl --columns=tunnel_key list Logical_Switch | grep 1`"])
 # now should see the tunnel key reset.
 AT_CHECK([vtep-ctl --columns=tunnel_key list Logical_Switch | cut -d ':' -f2 | tr -d ' '], [0], [dnl
@@ -337,25 +338,25 @@ OVN_CONTROLLER_VTEP_START
 
 # creates a simple logical network with the vtep device and a fake hv chassis
 # 'ch0'.
-AT_CHECK([ovn-nbctl lport-add br-test vif0])
-AT_CHECK([ovn-nbctl lport-set-addresses vif0 f0:ab:cd:ef:01:02])
-AT_CHECK([ovn-sbctl chassis-add ch0 vxlan 1.2.3.5])
-AT_CHECK([ovn-sbctl lport-bind vif0 ch0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add br-test vif0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif0 f0:ab:cd:ef:01:02])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock chassis-add ch0 vxlan 1.2.3.5])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock lport-bind vif0 ch0])
 
 # creates the logical switch in vtep and adds the corresponding logical
 # port to 'br-test'.
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0])
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-vtep_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-vtep_lswitch0`"])
 
 # adds another lswitch 'br-void' in ovn-nb database.
-AT_CHECK([ovn-nbctl lswitch-add br-void])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lswitch-add br-void])
 # adds fake hv chassis 'ch1'.
-AT_CHECK([ovn-nbctl lport-add br-void vif1])
-AT_CHECK([ovn-nbctl lport-set-addresses vif1 f0:ab:cd:ef:01:02])
-AT_CHECK([ovn-sbctl chassis-add ch1 vxlan 1.2.3.6])
-AT_CHECK([ovn-sbctl lport-bind vif1 ch1])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding | grep vif1`"])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add br-void vif1])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif1 f0:ab:cd:ef:01:02])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock chassis-add ch1 vxlan 1.2.3.6])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock lport-bind vif1 ch1])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding | grep vif1`"])
 
 # checks Ucast_Macs_Remote creation.
 OVS_WAIT_UNTIL([test -n "`vtep-ctl list Ucast_Macs_Remote | grep _uuid`"])
@@ -376,7 +377,7 @@ AT_CHECK([ovs-vsctl --columns=options list Interface bfd1.2.3.5 | cut -d ':' -f2
 ])
 
 # adds another mac to lport.
-AT_CHECK([ovn-nbctl lport-set-addresses vif0 f0:ab:cd:ef:01:02 f0:ab:cd:ef:01:03])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif0 f0:ab:cd:ef:01:02 f0:ab:cd:ef:01:03])
 OVS_WAIT_UNTIL([test -n "`vtep-ctl list Ucast_Macs_Remote | grep 03`"])
 AT_CHECK([vtep-ctl --columns=MAC list Ucast_Macs_Remote | cut -d ':' -f2- | tr -d ' ' | sort], [0], [dnl
 
@@ -385,15 +386,15 @@ AT_CHECK([vtep-ctl --columns=MAC list Ucast_Macs_Remote | cut -d ':' -f2- | tr -
 ])
 
 # removes one mac to lport.
-AT_CHECK([ovn-nbctl lport-set-addresses vif0 f0:ab:cd:ef:01:03])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif0 f0:ab:cd:ef:01:03])
 OVS_WAIT_UNTIL([test -z "`vtep-ctl --columns=MAC list Ucast_Macs_Remote | grep 02`"])
 AT_CHECK([vtep-ctl --columns=MAC list Ucast_Macs_Remote | cut -d ':' -f2- | tr -d ' ' | sort], [0], [dnl
 "f0:ab:cd:ef:01:03"
 ])
 
 # migrates mac to lport vif1 on 'br-void'.
-AT_CHECK([ovn-nbctl lport-set-addresses vif0])
-AT_CHECK([ovn-nbctl lport-set-addresses vif1 f0:ab:cd:ef:01:03])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif1 f0:ab:cd:ef:01:03])
 OVS_WAIT_UNTIL([test -z "`vtep-ctl --columns=MAC list Ucast_Macs_Remote | grep 03`"])
 AT_CHECK([vtep-ctl --columns=MAC list Ucast_Macs_Remote | cut -d ':' -f2- | tr -d ' ' | sort], [0], [dnl
 ])
@@ -408,21 +409,21 @@ OVN_CONTROLLER_VTEP_START
 
 # creates a simple logical network with the vtep device and a fake hv chassis
 # 'ch0'.
-AT_CHECK([ovn-nbctl lport-add br-test vif0])
-AT_CHECK([ovn-nbctl lport-set-addresses vif0 f0:ab:cd:ef:01:02])
-AT_CHECK([ovn-sbctl chassis-add ch0 vxlan 1.2.3.5])
-AT_CHECK([ovn-sbctl lport-bind vif0 ch0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add br-test vif0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif0 f0:ab:cd:ef:01:02])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock chassis-add ch0 vxlan 1.2.3.5])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock lport-bind vif0 ch0])
 
 # creates another vif in the same logical switch with duplicate mac.
-AT_CHECK([ovn-nbctl lport-add br-test vif1])
-AT_CHECK([ovn-nbctl lport-set-addresses vif1 f0:ab:cd:ef:01:02])
-AT_CHECK([ovn-sbctl lport-bind vif1 ch0])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add br-test vif1])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif1 f0:ab:cd:ef:01:02])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock lport-bind vif1 ch0])
 
 # creates the logical switch in vtep and adds the corresponding logical
 # port to 'br-test'.
 AT_CHECK([vtep-ctl add-ls lswitch0 -- bind-ls br-vtep p0 100 lswitch0])
 OVN_NB_ADD_VTEP_PORT([br-test], [br-vtep_lswitch0], [br-vtep], [lswitch0])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-vtep_lswitch0`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-vtep_lswitch0`"])
 
 # checks Ucast_Macs_Remote creation.  Should still only be one entry, since duplicate
 # mac in the same logical switch is not allowed.
@@ -437,22 +438,22 @@ AT_CHECK([sed -n 's/^.*\(|WARN|.*\)$/\1/p' ovn-controller-vtep.log | sed 's/([[-
 ])
 
 # deletes vif1.
-AT_CHECK([ovn-nbctl lport-del vif1])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-del vif1])
 
 # adds another lswitch 'br-void' in ovn-nb database.
-AT_CHECK([ovn-nbctl lswitch-add br-void])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lswitch-add br-void])
 # adds fake hv chassis 'ch1' and vif1 with same mac address as vif0.
-AT_CHECK([ovn-nbctl lport-add br-void vif1])
-AT_CHECK([ovn-nbctl lport-set-addresses vif1 f0:ab:cd:ef:01:02])
-AT_CHECK([ovn-sbctl chassis-add ch1 vxlan 1.2.3.6])
-AT_CHECK([ovn-sbctl lport-bind vif1 ch1])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding | grep vif1`"])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-add br-void vif1])
+AT_CHECK([ovn-nbctl --db=unix:$OVS_RUNDIR/db.sock lport-set-addresses vif1 f0:ab:cd:ef:01:02])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock chassis-add ch1 vxlan 1.2.3.6])
+AT_CHECK([ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock lport-bind vif1 ch1])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding | grep vif1`"])
 
 # creates another logical switch in vtep and adds the corresponding logical
 # port to 'br-void'.
 AT_CHECK([vtep-ctl add-ls lswitch1 -- bind-ls br-vtep p0 200 lswitch1])
 OVN_NB_ADD_VTEP_PORT([br-void], [br-void_lswitch1], [br-vtep], [lswitch1])
-OVS_WAIT_UNTIL([test -n "`ovn-sbctl list Port_Binding  | grep br-void_lswitch1`"])
+OVS_WAIT_UNTIL([test -n "`ovn-sbctl --db=unix:$OVS_RUNDIR/db.sock list Port_Binding  | grep br-void_lswitch1`"])
 
 # checks Ucast_Macs_Remote creation.  Should see two entries since it is allowed
 # to have duplicate macs in different logical switches.

--- a/tests/ovn-nbctl.at
+++ b/tests/ovn-nbctl.at
@@ -7,7 +7,7 @@ m4_define([OVN_NBCTL_TEST_START],
    AT_CHECK([ovsdb-tool create ovn-nb.db $abs_top_srcdir/ovn/ovn-nb.ovsschema])
 
    dnl Start ovsdb-server.
-   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/db.sock ovn-nb.db], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/ovnnb_db.sock ovn-nb.db], [0], [], [stderr])
    on_exit "kill `cat ovsdb-server.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d

--- a/tests/ovn-sbctl.at
+++ b/tests/ovn-sbctl.at
@@ -8,16 +8,17 @@ m4_define([OVN_SBCTL_TEST_START],
       AT_CHECK([ovsdb-tool create $daemon.db $abs_top_srcdir/${daemon%%-*}/${daemon}.ovsschema])
    done
 
-   dnl Start ovsdb-server.
-   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/db.sock ovn-nb.db ovn-sb.db], [0], [], [stderr])
-   on_exit "kill `cat ovsdb-server.pid`"
+   dnl Start ovsdb-servers.
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovnnb_db.pid --log-file=$OVS_RUNDIR/ovsdb_nb.log --remote=punix:$OVS_RUNDIR/ovnnb_db.sock ovn-nb.db ], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovnsb_db.pid --log-file=$OVS_RUNDIR/ovsdb_sb.log --remote=punix:$OVS_RUNDIR/ovnsb_db.sock ovn-sb.db], [0], [], [stderr])
+   on_exit "kill `cat ovnnb_db.pid` `cat ovnsb_db.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d
 /ovsdb_server|INFO|ovsdb-server (Open vSwitch)/d']])
    AT_CAPTURE_FILE([ovsdb-server.log])
 
    dnl Start ovn-northd.
-   AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/db.sock], [0], [], [stderr])
+   AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/ovnnb_db.sock --ovnsb-db=unix:$OVS_RUNDIR/ovnsb_db.sock], [0], [], [stderr])
    on_exit "kill `cat ovn-northd.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d']])
@@ -36,7 +37,8 @@ m4_define([OVN_SBCTL_TEST_STOP],
    AT_CHECK([check_logs "$1
 /Broken pipe/d"])
    AT_CHECK([ovs-appctl -t ovn-northd exit])
-   AT_CHECK([ovs-appctl -t ovsdb-server exit])])
+   AT_CHECK([ovs-appctl --target=$OVS_RUNDIR/ovsdb-server.`cat ovnnb_db.pid`.ctl exit])
+   AT_CHECK([ovs-appctl --target=$OVS_RUNDIR/ovsdb-server.`cat ovnsb_db.pid`.ctl exit])])
 
 dnl ---------------------------------------------------------------------
 


### PR DESCRIPTION
OVN NB & SB DB's should be run in separate ovsdb-server processes
and should run with ovn-ctl start_northd / stop_northd.
Includes changes to debian template to have service initialize things
correctly

Signed-off-by: Ryan Moats rmoats@us.ibm.com
