### PR TITLE
Debian package: fix ovn ovsdb-server start/stop issues

### DIFF
--- a/debian/ovn-central.init
+++ b/debian/ovn-central.init
@@ -28,12 +28,18 @@ start () {
     "$@" || exit $?
 }
 
+stop_northd () {
+    set /usr/share/openvswitch/scripts/ovn-ctl ${1-stop_northd}
+    set "$@" $OVN_CTL_OPTS
+    "$@" || exit $?
+}
+
 case $1 in
     start)
         start
         ;;
     stop)
-        /usr/share/openvswitch/scripts/ovn-ctl stop_northd
+        stop_northd
         ;;
     restart)
         start restart_northd

--- a/debian/ovn-central.template
+++ b/debian/ovn-central.template
@@ -2,12 +2,13 @@
 
 # OVN_CTL_OPTS: Extra options to pass to ovs-ctl.  This is, for example,
 # a suitable place to specify --ovn-northd-wrapper=valgrind.
-OVN_CTL_OPTS="--db-nb-port=6641 \
+HOST_IP=${HOST_IP:-0.0.0.0}
+OVN_CTL_OPTS="--db-nb-port=6641:$HOST_IP \
     --db-nb-sock=/var/run/openvswitch/nb_db.sock \
     --db-nb-pid=/var/run/openvswitch/ovsdb-server-nb.pid \
     --db-nb-file=/etc/openvswitch/ovnnb.db \
     --ovn-nb-logfile=/var/log/openvswitch/ovsdb-server-nb.log \
-    --db-sb-port=6640 \
+    --db-sb-port=6640:$HOST_IP \
     --db-sb-sock=/var/run/openvswitch/sb_db.sock \
     --db-sb-pid=/var/run/openvswitch/ovsdb-server-sb.pid \
     --db-sb-file=/etc/openvswitch/ovnsb.db \


### PR DESCRIPTION
Update ovn-central template to include a HOST_IP variable
for ovsdb-server processes that can be ansibilized and
set to 0.0.0.0 for now. Also change ovn-central.init script
to ensure that stopping ovn-northd actually stops related
ovsdb-server processes.

Signed-off-by: RYAN D. MOATS rmoats@us.ibm.com
